### PR TITLE
Fix get method on StitchNestedListElement Array

### DIFF
--- a/Sources/StitchViewKit/StitchNestedList/Model/StitchNestedListElement.swift
+++ b/Sources/StitchViewKit/StitchNestedList/Model/StitchNestedListElement.swift
@@ -228,7 +228,7 @@ extension Array where Element: StitchNestedListElement {
     
     public func get(_ id: Element.ID) -> Element? {
         for item in self {
-            if item.id == item.id {
+            if Sources/StitchViewKit/StitchNestedList/Model/StitchNestedListElement.swiftid == item.id {
                 return item
             }
             

--- a/Sources/StitchViewKit/StitchNestedList/Model/StitchNestedListElement.swift
+++ b/Sources/StitchViewKit/StitchNestedList/Model/StitchNestedListElement.swift
@@ -228,7 +228,7 @@ extension Array where Element: StitchNestedListElement {
     
     public func get(_ id: Element.ID) -> Element? {
         for item in self {
-            if Sources/StitchViewKit/StitchNestedList/Model/StitchNestedListElement.swiftid == item.id {
+            if id == item.id {
                 return item
             }
             


### PR DESCRIPTION
Traced another bug in the main app to this method so just biting the bullet and fixing it now.