### PR TITLE
Fixed issue where new groups could remove children

### DIFF
--- a/Sources/StitchViewKit/StitchNestedList/Model/StitchNestedListElement.swift
+++ b/Sources/StitchViewKit/StitchNestedList/Model/StitchNestedListElement.swift
@@ -323,13 +323,24 @@ extension Array where Element: StitchNestedListElement {
             return
         }
         
-        // Remove selections from list
-        selections.forEach {
-            self.remove($0)
-        }
+        // Remove selections from list, complete in order due to grouping
+        var newList = self.removeSelections(selections)
         
         // Add new group node to sidebar
-        self.insert(group, at: newGroupIndex)
+        newList.insert(group, at: newGroupIndex)
+        self = newList
+    }
+    
+    func removeSelections(_ selections: Set<Element.ID>) -> [Element] {
+        self.compactMap { item in
+            if selections.contains(item.id) {
+                return nil
+            }
+            
+            var item = item
+            item.children = item.children?.removeSelections(selections)
+            return item
+        }
     }
     
     public func ungroup(selectedGroupId: Element.ID) -> [Element] {


### PR DESCRIPTION
Issue was due to inconsistencies from unordered set elements. The fix was iterating through the existing list in order for removing selected elements.